### PR TITLE
Add sshd Docker image

### DIFF
--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -10,8 +10,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /var/run/sshd \
     && sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin no/' /etc/ssh/sshd_config \
-    && sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config \
-    && passwd -l root
+    && sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV INITIAL_USER=""
+
+RUN apt-get update && apt-get install -y \
+    openssh-server \
+    sudo \
+    libpam-script \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /var/run/sshd \
+    && sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config \
+    && echo 'root:root' | chpasswd
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 22
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update && apt-get install -y \
     libpam-script \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /var/run/sshd \
-    && sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin no/' /etc/ssh/sshd_config \
     && sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config \
-    && echo 'root:root' | chpasswd
+    && passwd -l root
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/sshd/entrypoint.sh
+++ b/sshd/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# Create user if INITIAL_USER is set
+if [ -n "$INITIAL_USER" ]; then
+    echo "Creating user: $INITIAL_USER"
+    
+    # Check if user already exists
+    if ! id "$INITIAL_USER" &>/dev/null; then
+        # Create user with home directory and bash shell
+        useradd -m -s /bin/bash "$INITIAL_USER"
+        
+        # Set a default password (same as username)
+        echo "$INITIAL_USER:$INITIAL_USER" | chpasswd
+        
+        # Add user to sudo group
+        usermod -aG sudo "$INITIAL_USER"
+        
+        echo "User $INITIAL_USER created successfully"
+    else
+        echo "User $INITIAL_USER already exists"
+    fi
+fi
+
+# Generate SSH host keys if they don't exist
+if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
+    ssh-keygen -A
+fi
+
+# Create privilege separation directory if it doesn't exist
+if [ ! -d /run/sshd ]; then
+    mkdir -p /run/sshd
+    chmod 755 /run/sshd
+fi
+
+# Start SSH daemon in foreground
+echo "Starting SSH daemon..."
+exec /usr/sbin/sshd -D


### PR DESCRIPTION
## Summary
- Added new Docker image `sshd` based on Ubuntu 22.04
- Configured SSH daemon with automatic startup via entrypoint.sh
- Implemented dynamic user creation through INITIAL_USER environment variable
- Enabled PAM support with libpam-script

## Features
- **Base image**: Ubuntu 22.04
- **SSH access**: Port 22 exposed for SSH connections
- **Dynamic user creation**: Creates a Unix user at runtime based on INITIAL_USER environment variable
- **PAM support**: libpam-script installed for PAM execution capabilities
- **Auto-configuration**: SSH host keys generated automatically if not present

## Test plan
- [ ] Build the Docker image: `docker build -t sshd sshd/`
- [ ] Run container without INITIAL_USER: `docker run -d -p 2222:22 sshd`
- [ ] Run container with INITIAL_USER: `docker run -d -p 2222:22 -e INITIAL_USER=testuser sshd`
- [ ] Verify SSH connection: `ssh testuser@localhost -p 2222` (password: testuser)
- [ ] Verify PAM functionality is available

🤖 Generated with [Claude Code](https://claude.ai/code)