### PR TITLE
Add sshd Docker image with security improvements

### DIFF
--- a/.github/workflows/build_sshd.yaml
+++ b/.github/workflows/build_sshd.yaml
@@ -1,0 +1,19 @@
+name: "build sshd"
+
+on:
+  push:
+    paths:
+      - 'sshd/**'
+      - '.github/workflows/build_sshd.yaml'
+  pull_request:
+    paths:
+      - 'sshd/**'
+      - '.github/workflows/build_sshd.yaml'
+
+jobs:
+  build:
+    uses: takutakahashi/github-actions/.github/workflows/ghcr.yaml@main
+    with:
+      path: sshd
+      image: takutakahashi/sshd:${{ github.sha }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Added new Docker image `sshd` based on Ubuntu 22.04
- Configured SSH daemon with automatic startup via entrypoint.sh
- Implemented dynamic user creation through INITIAL_USER environment variable
- Enabled PAM support with libpam-script
- Added GitHub Actions workflow for automated builds

## Security Features
- **SSH Root Login**: Disabled (PermitRootLogin no)
- **Root Account**: Not locked, accessible via docker exec for maintenance
- **User Creation**: Dynamic user creation with INITIAL_USER environment variable
- **Password Authentication**: Enabled for created users

## Features
- **Base image**: Ubuntu 22.04
- **SSH access**: Port 22 exposed for SSH connections
- **Dynamic user creation**: Creates a Unix user at runtime based on INITIAL_USER environment variable
- **PAM support**: libpam-script installed for PAM execution capabilities
- **Auto-configuration**: SSH host keys generated automatically if not present

## Test plan
- [ ] Build the Docker image: `docker build -t sshd sshd/`
- [ ] Run container without INITIAL_USER: `docker run -d -p 2222:22 sshd`
- [ ] Run container with INITIAL_USER: `docker run -d -p 2222:22 -e INITIAL_USER=testuser sshd`
- [ ] Verify SSH connection: `ssh testuser@localhost -p 2222` (password: testuser)
- [ ] Verify PAM functionality is available
- [ ] Verify root cannot SSH in
- [ ] Verify root is accessible via docker exec

🤖 Generated with [Claude Code](https://claude.ai/code)